### PR TITLE
Remove double slash from path

### DIFF
--- a/src/js/h5p-overwrite.js
+++ b/src/js/h5p-overwrite.js
@@ -13,7 +13,7 @@ H5P.getPath = function (path, contentId) {
 
   var prefix;
   if (contentId !== undefined) {
-    prefix = H5PIntegration.url + '/content/';
+    prefix = H5PIntegration.url + '/content';
   }
   else if (window.H5PEditor !== undefined) {
     prefix = H5PEditor.filesPath;


### PR DESCRIPTION
The slash after content caused a double slash in the resulting path, standalone could not be loaded in a simple Android WebView app. See detailed error description here: https://h5p.org/node/104774

Thanks for providing!