### PR TITLE
Fix #56 don't modify path if it is relative to the site root

### DIFF
--- a/src/js/h5p-standalone.class.js
+++ b/src/js/h5p-standalone.class.js
@@ -7,6 +7,9 @@ function urlPath(file) {
   if (file.match(/^[a-z0-9]+:\/\//i)) {
     return file;
   }
+  if (file.match(/^\//)) {
+    return file;
+  }
   let prefix = window.location.protocol + "//" + window.location.host;
 
   if (window.location.pathname.indexOf('/') > -1) {


### PR DESCRIPTION
When the H5P path is relative to the site root i.e. ("/h5p/content") don't modify the path. 

Fixes #56 