### PR TITLE
ci: fix issue with Cypress@7^ that requires Node >= v12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       - name: Install dependencies
         run: yarn --frozen-lockfile


### PR DESCRIPTION
 Cypress@7^ requires Node >= v12.0.0