### PR TITLE
fix: properly cache the Cypress binary - Github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           path: |
             ~/.cache/yarn
+            ~/.cache/Cypress
             **/node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
 


### PR DESCRIPTION
Release pipeline breaking due to a missing Cypress binary in the cached dependencies

BREAKING CHANGE: Cypress binary is now cached during release action