### PR TITLE
Allow passing content data to H5P instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The standalone H5P player constructor accepts two arguments.
 `downloadUrl` |false| A path or a url that returns zipped h5p for download. The link is used by H5P `export` button
 `fullScreen` |false| A boolean on whether to enable fullscreen button if browser supports the feature. Default is `false`|
 `xAPIObjectIRI`|false| An identifier for a single unique Activity ~ utilized when generating xAPI [object](https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#acturi) field. Default is page host+pathname
+`extras` |false|  Object containig extra data passed to the H5P when creating the Runnable instance.
 
 **Note:**
 - One can use absolute URL for `frameCss`, `frameJs`, and for other path options(`h5pJsonPath`,`librariesPath`, & `librariesPath`)

--- a/cypress/integration/advance-options.spec.js
+++ b/cypress/integration/advance-options.spec.js
@@ -6,6 +6,9 @@ describe('single', () => {
         cy.get('.h5p-iframe').should(iframe => {
             expect(iframe.contents().find('.h5p-content')).to.exist;
 
+            // Using extra options to pre-check answer
+            expect(iframe.contents().find('.h5p-true-false-answer[aria-checked="true"]')).to.exist
+
             iframe.contents().find('.h5p-true-false-answer').click();
 
             iframe.contents().find('.h5p-question-check-answer').click();

--- a/src/js/h5p-standalone.class.js
+++ b/src/js/h5p-standalone.class.js
@@ -89,6 +89,9 @@ export default class H5PStandalone {
       contentOptions.url = options.xAPIObjectIRI; //no validation
     }
 
+    if (options.extras) {
+      contentOptions.extras = options.extras;
+    }
 
     this.initElement(el);
     return this.initH5P(generalIntegrationOptions, contentOptions);

--- a/test/advance-options.html
+++ b/test/advance-options.html
@@ -21,6 +21,7 @@
       copyright: true,
       embed: false,
       export: true,
+      extras: { previousState: { answer: false } },
       downloadUrl: 'test.h5p'
     });
   </script>

--- a/vendor/h5p/js/h5p.js
+++ b/vendor/h5p/js/h5p.js
@@ -2446,7 +2446,12 @@ H5P.createTitle = function (rawTitle, maxLength) {
 
         // Done. Try to decode JSON
         try {
-          done(undefined, JSON.parse(data));
+          if (typeof(data) == 'string') {
+            done(undefined, JSON.parse(data));
+          } else {
+            // No need to parse
+            done(undefined, data);
+          }          
         }
         catch (e) {
           done(e);

--- a/vendor/h5p/js/h5p.js
+++ b/vendor/h5p/js/h5p.js
@@ -160,8 +160,13 @@ H5P.init = function (target) {
       // If previousState is false we don't have a previous state
     });
 
+    let extras = { standalone: true }
+    if (typeof(contentData.extras) == 'object') {
+      extras = Object.assign(extras, contentData.extras)
+    }
+
     // Create new instance.
-    var instance = H5P.newRunnable(library, contentId, $container, true, {standalone: true});
+    var instance = H5P.newRunnable(library, contentId, $container, true, extras);
 
     H5P.offlineRequestQueue = new H5P.OfflineRequestQueue({instance: instance});
 


### PR DESCRIPTION
Some H5P Content-Types expect a third parameter with external content data. This PR allows passing such data during H5P initialisation.

Used the previousState from the TrueFalse content type for testing purposes
