### PR TITLE
Allow to specify metadata

### DIFF
--- a/src/js/h5p-standalone.class.js
+++ b/src/js/h5p-standalone.class.js
@@ -64,6 +64,10 @@ export default class H5PStandalone {
       contentOptions.exportUrl = urlPath(options.downloadUrl);
     }
 
+    if (options.metadata) {
+      contentOptions.metadata = options.metadata;
+    }
+
     const generalIntegrationOptions = {
       preventH5PInit: options.preventH5PInit ? options.preventH5PInit : false,
     };


### PR DESCRIPTION
This allows to specify a metadata key ( to specify the language, for instance ).

Fixes https://github.com/tunapanda/h5p-standalone/issues/92