### PR TITLE
fix: remove github release archive from npm release files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ cypress
 .circleci
 .eslintrc.json
 cypress.json
+h5p-standalone-release.zip


### PR DESCRIPTION
 Removes Github release archive generated during release pipeline from NPM release files