### PR TITLE
build: fix flaky cypress tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,21 @@ node_modules
 .DS_Store
 cypress/videos
 dist
+.idea
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history/*

--- a/cypress/integration/advance-options.spec.js
+++ b/cypress/integration/advance-options.spec.js
@@ -4,7 +4,7 @@ describe("H5P player with advance options", () => {
   });
 
   it("should display h5p", () => {
-    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+    cy.iframe("iframe.h5p-iframe.h5p-initialized")
       .should("be.visible")
       .within(() => {
         cy.get(".h5p-true-false-answers .h5p-true-false-answer")
@@ -17,7 +17,7 @@ describe("H5P player with advance options", () => {
   });
 
   it("should display export dialog", () => {
-    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized").within(() => {
+    cy.iframe("iframe.h5p-iframe.h5p-initialized").within(() => {
       cy.get(".h5p-actions").find(".h5p-export").should("be.visible").click();
 
       cy.get(".h5p-download-button").should("be.visible");
@@ -25,7 +25,7 @@ describe("H5P player with advance options", () => {
   });
 
   it("should display embed code dialog", () => {
-    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized").within(() => {
+    cy.iframe("iframe.h5p-iframe.h5p-initialized").within(() => {
       cy.get(".h5p-actions").find(".h5p-embed").should("be.visible").click();
 
       cy.get(".h5p-embed-code-container").should("be.visible");

--- a/cypress/integration/advance-options.spec.js
+++ b/cypress/integration/advance-options.spec.js
@@ -1,43 +1,35 @@
-describe('single', () => {
-    it('should display h5p', () => {
+describe("H5P player with advance options", () => {
+  beforeEach(() => {
+    cy.visit("test/advance-options.html");
+  });
 
-        cy.visit('test/advance-options.html');
+  it("should display h5p", () => {
+    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+      .should("be.visible")
+      .within(() => {
+        cy.get(".h5p-true-false-answers .h5p-true-false-answer")
+          .contains("False")
+          .click();
 
-        cy.get('.h5p-iframe').should(iframe => {
-            expect(iframe.contents().find('.h5p-content')).to.exist;
+        cy.get(".h5p-question-check-answer").click();
+        cy.get(".h5p-joubelui-score-bar-star").should("be.visible");
+      });
+  });
 
-            iframe.contents().find('.h5p-true-false-answer').click();
+  it("should display export dialog", () => {
+    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized").within(() => {
+      cy.get(".h5p-actions").find(".h5p-export").should("be.visible").click();
 
-            iframe.contents().find('.h5p-question-check-answer').click();
-
-            expect(iframe.contents().find('.h5p-joubelui-score-bar-star')).to.exist;
-
-            expect(iframe.contents().find('.h5p-actions').find('.h5p-export')).to.exist;
-
-            iframe.contents()
-                .find('.h5p-actions')
-                .find('.h5p-export')
-                .click();
-
-            expect(iframe.contents().find('.h5p-download-button')).to.exist;
-        });
+      cy.get(".h5p-download-button").should("be.visible");
     });
+  });
 
-    it('should display embed code dialog', () => {
+  it("should display embed code dialog", () => {
+    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized").within(() => {
+      cy.get(".h5p-actions").find(".h5p-embed").should("be.visible").click();
 
-        cy.visit('test/advance-options.html');
-        cy.get('.h5p-iframe').should((iframe) => {
-
-            expect(iframe.contents().find('.h5p-actions').find('.h5p-embed')).to.exist;
-
-            iframe.contents()
-                .find('.h5p-actions')
-                .find('.h5p-embed')
-                .click();
-
-            expect(iframe.contents().find('.h5p-embed-code-container')).to.exist;
-            expect(iframe.contents().find('.h5p-embed-size')).to.exist;
-        })
-
+      cy.get(".h5p-embed-code-container").should("be.visible");
+      cy.get(".h5p-embed-size").should("be.visible");
     });
+  });
 });

--- a/cypress/integration/external_libraries.spec.js
+++ b/cypress/integration/external_libraries.spec.js
@@ -1,16 +1,19 @@
-describe('external libraries', () => {
-  it('should display h5p', () => {
+describe("H5P player loading external libraries", () => {
+  beforeEach(() => {
+    cy.visit("test/external_libraries.html");
+  });
 
-    cy.visit('test/external_libraries.html');
+  it("should display h5p", () => {
+    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+      .should("be.visible")
+      .within(() => {
+        cy.get(".h5p-true-false-answers .h5p-true-false-answer")
+          .contains("False")
+          .click();
 
-    cy.get('.h5p-iframe').should(iframe => {
-      expect(iframe.contents().find('.h5p-content')).to.exist;
+        cy.get(".h5p-question-check-answer").click();
 
-      iframe.contents().find('.h5p-true-false-answer').click();
-
-      iframe.contents().find('.h5p-question-check-answer').click();
-
-      expect(iframe.contents().find('.h5p-joubelui-score-bar-star')).to.exist;
-    });
+        cy.get(".h5p-joubelui-score-bar-star").should("be.visible");
+      });
   });
 });

--- a/cypress/integration/external_libraries.spec.js
+++ b/cypress/integration/external_libraries.spec.js
@@ -4,7 +4,7 @@ describe("H5P player loading external libraries", () => {
   });
 
   it("should display h5p", () => {
-    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+    cy.iframe("iframe.h5p-iframe.h5p-initialized")
       .should("be.visible")
       .within(() => {
         cy.get(".h5p-true-false-answers .h5p-true-false-answer")

--- a/cypress/integration/multiple.spec.js
+++ b/cypress/integration/multiple.spec.js
@@ -4,7 +4,7 @@ describe("Multiple H5P players", () => {
   });
 
   it("should display & load multiple h5p players", () => {
-    cy.iframe("#h5p-container-1 iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+    cy.iframe("#h5p-container-1 iframe.h5p-iframe.h5p-initialized")
       .should("be.visible")
       .within(() => {
         cy.get(".h5p-true-false-answers .h5p-true-false-answer")
@@ -15,7 +15,7 @@ describe("Multiple H5P players", () => {
 
         cy.get(".h5p-joubelui-score-bar-star").should("be.visible");
       });
-    cy.iframe("#h5p-container-2  iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+    cy.iframe("#h5p-container-2  iframe.h5p-iframe.h5p-initialized")
       .should("be.visible")
       .within(() => {
         cy.get(".h5p-true-false-answers .h5p-true-false-answer")

--- a/cypress/integration/multiple.spec.js
+++ b/cypress/integration/multiple.spec.js
@@ -1,14 +1,30 @@
-describe('multiple', () => {
-  it('should display 2 h5ps', () => {
+describe("Multiple H5P players", () => {
+  beforeEach(() => {
+    cy.visit("test/multiple.html");
+  });
 
-    cy.visit('test/multiple.html');
+  it("should display & load multiple h5p players", () => {
+    cy.iframe("#h5p-container-1 iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+      .should("be.visible")
+      .within(() => {
+        cy.get(".h5p-true-false-answers .h5p-true-false-answer")
+          .contains("False")
+          .click();
 
-    cy.get('#h5p-container-1 .h5p-iframe').should(iframe => {
-      expect(iframe.contents().find('.h5p-content')).to.exist;
-    });
+        cy.get(".h5p-question-check-answer").click();
 
-    cy.get('#h5p-container-2 .h5p-iframe').should(iframe => {
-      expect(iframe.contents().find('.h5p-content')).to.exist;
-    });
+        cy.get(".h5p-joubelui-score-bar-star").should("be.visible");
+      });
+    cy.iframe("#h5p-container-2  iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+      .should("be.visible")
+      .within(() => {
+        cy.get(".h5p-true-false-answers .h5p-true-false-answer")
+          .contains("False")
+          .click();
+
+        cy.get(".h5p-question-check-answer").click();
+
+        cy.get(".h5p-joubelui-score-bar-star").should("be.visible");
+      });
   });
 });

--- a/cypress/integration/single.spec.js
+++ b/cypress/integration/single.spec.js
@@ -4,7 +4,7 @@ describe("Single H5P player", () => {
   });
 
   it("should display h5p", () => {
-    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+    cy.iframe("iframe.h5p-iframe.h5p-initialized")
       .should("be.visible")
       .within(() => {
         cy.get(".h5p-true-false-answers .h5p-true-false-answer")

--- a/cypress/integration/single.spec.js
+++ b/cypress/integration/single.spec.js
@@ -1,16 +1,19 @@
-describe('single', () => {
-  it('should display h5p', () => {
+describe("Single H5P player", () => {
+  beforeEach(() => {
+    cy.visit("test/single.html");
+  });
 
-    cy.visit('test/single.html');
+  it("should display h5p", () => {
+    cy.iframe("iframe.h5p-iframe.h5p-iframe.h5p-initialized")
+      .should("be.visible")
+      .within(() => {
+        cy.get(".h5p-true-false-answers .h5p-true-false-answer")
+          .contains("False")
+          .click();
 
-    cy.get('.h5p-iframe').should(iframe => {
-      expect(iframe.contents().find('.h5p-content')).to.exist;
+        cy.get(".h5p-question-check-answer").click();
 
-      iframe.contents().find('.h5p-true-false-answer').click();
-
-      iframe.contents().find('.h5p-question-check-answer').click();
-
-      expect(iframe.contents().find('.h5p-joubelui-score-bar-star')).to.exist;
-    });
+        cy.get(".h5p-joubelui-score-bar-star").should("be.visible");
+      });
   });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -26,10 +26,10 @@ module.exports = (on, config) => {
 
     on('task', {
         'unzip:h5p': async () => {
-            await fs.createReadStream(`${workspace}${h5pFile}`)
+            return await fs.createReadStream(`${workspace}${h5pFile}`)
                 .pipe(unzipper.Extract({path: `${workspace}${extractFolder}`}))
-                .promise();
-            return true;
+                .promise()
+                .then(() => true);
         },
         'copy:libraries': () => {
             const H5PLibraries = ['Drop-1.0', 'FontAwesome-4.5', 'H5P.FontIcons-1.0', 'H5P.JoubelUI-1.3',

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,7 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.add("iframe", (selector) => {
+  return cy.get(selector).its("0.contentDocument.body").then(cy.wrap);
+});


### PR DESCRIPTION
1)  `cy.task` does not wait for the extraction of H5P to finish. Issue fixed by ensuring the async task returns a promise that resolves to true. [Reference](https://docs.cypress.io/api/commands/task#Return-a-Promise-from-an-asynchronous-task)
2)  Assertions run before H5P content is fully  is initialized. Issue fixed by ensuring iframe body is loaded if `.h5p-initialized` class exists.