### PR TITLE
Fixes `Module parse failed: Unexpected token` error

### DIFF
--- a/src/js/h5p-standalone.class.js
+++ b/src/js/h5p-standalone.class.js
@@ -185,8 +185,7 @@ export default class H5PStandalone {
     // add missing content metadata from h5p.json
     for (const key in this.h5p) {
       if (H5PIntegration.contents[`cid-${this.id}`]?.['metadata']?.[key] === undefined) {
-        console.log(H5PIntegration.contents[`cid-${this.id}`])
-        H5PIntegration.contents[`cid-${this.id}`].['metadata'].[key] = this.h5p[key]
+        H5PIntegration.contents[`cid-${this.id}`]['metadata'][key] = this.h5p[key]
       }
     }
 


### PR DESCRIPTION
Fixes the error

```
ERROR in ./src/js/h5p-standalone.class.js 188:50
Module parse failed: Unexpected token (188:50)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|     for (const key in this.h5p) {
|       if (H5PIntegration.contents[`cid-${this.id}`]?.['metadata']?.[key] === undefined) {
>         H5PIntegration.contents[`cid-${this.id}`].['metadata'].[key] = this.h5p[key]
|       }
|     }
 @ ./src/js/index.js 2:0-51 10:22-35
```