### PR TITLE
feat: allow dev url to match regex (eg :`localhost:8080`)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ export function urlPath(path: string): string {
     path = path.trim();
 
     //regex to check if is an absolute url (with *a* protocol) or a valid URI
-    const urlRegex = /^([a-z0-9]+:\/\/|www.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i;
+    const urlRegex = /^([a-z0-9]+:\/\/|www.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}(\.[a-z]{2,6}|(?::\d{1,5}))\b([-a-zA-Z0-9@:%_\+.~#?&=]*)/i;
 
     if (path.match(urlRegex)) {
         return path;


### PR DESCRIPTION
My H5P server is hosted locally and I need to provide the `librariesPath` option parameter as `localhost:8080/library` (which is invalid with the current regex and replaced by `<CURRENT_PATH>/localhost:8080/library`)