### PR TITLE
fix: CORS issue while fetch assets

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export function urlPath(path: string): string {
 
 export async function getJSON<T>(url: string,requestOptions?: RequestInit): Promise<T> {
     if(!requestOptions){
-        requestOptions = {credentials: 'include'}
+        requestOptions = {credentials: 'same-origin'}
     }
     const res = await fetch(url,requestOptions);
     return res.json();


### PR DESCRIPTION
Fix CORS issue when fetching asset, because of incorrect credentials property value, changed from include to same-origin. tunapanda/h5p-standalone#151