### PR TITLE
fix: improve url regex validations

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,6 @@
   "homepage": "https://github.com/tunapanda/h5p-standalone#readme",
   "dependencies": {
     "@commitlint/cli": "^17.6.3"
-  }
+  },
+  "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e"
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "webpack-merge": "^5.8.0"
   },
   "scripts": {
+    "preinstall": "npx only-allow yarn",
     "watch": "webpack --watch --config webpack.dev.js",
     "start": "webpack-dev-server --mode development --config webpack.dev.js",
     "build:dev": "webpack --mode development --config webpack.dev.js",
@@ -64,6 +65,5 @@
   "homepage": "https://github.com/tunapanda/h5p-standalone#readme",
   "dependencies": {
     "@commitlint/cli": "^17.6.3"
-  },
-  "packageManager": "pnpm@9.6.0+sha512.38dc6fba8dba35b39340b9700112c2fe1e12f10b17134715a4aa98ccf7bb035e76fd981cf0bb384dfa98f8d6af5481c2bef2f4266a24bfa20c34eb7147ce0b5e"
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ export function urlPath(path: string): string {
     path = path.trim();
 
     //regex to check if is an absolute url (with *a* protocol) or a valid URI
-    const urlRegex = /^([a-z0-9]+:\/\/|www.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i;
+    const urlRegex = /^([a-z0-9]+:\/\/|www.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i;
 
     if (path.match(urlRegex)) {
         return path;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ export function urlPath(path: string): string {
     path = path.trim();
 
     //regex to check if is an absolute url (with *a* protocol) or a valid URI
-    const urlRegex = /^([a-z0-9]+:\/\/|www.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,63}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i;
+    const urlRegex = /^(https?:\/\/)?([a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*|localhost)(:\d{1,5})?(\/[^\s]*)?$/i
 
     if (path.match(urlRegex)) {
         return path;


### PR DESCRIPTION
This pull request enhances the URL regex validation to accommodate a broader range of valid URLs, including those with long top-level domains (TLDs) and those without TLDs, while ensuring compliance with standard URL formats.

fixes #160 
fixes #147