### PR TITLE
Add a step by step basic usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ The player can be set up either by directly calling the already built scripts an
    new H5PStandalone.H5P(el, options);
 
     ```
-    A detailed description of the H5P player arguments are provided  under the [advance section](#advanced-usage)
-    Simple instruction on how to extract H5P zipped file provided [here](#extracting-h5p)
+
+A detailed description of the H5P player arguments are provided under the [advanced usage section](#advanced-usage)
+
+Simple instructions on how to extract H5P zipped files are provided in the [extracting H5P section](#extracting-h5p)
+
+If you'd like a simple, step by step setup guide to direct usage, please see the [Basic setup guide](docs/basic-setup-guide.md)
 
 ### Using ES6
 Install the player using yarn

--- a/docs/basic-setup-guide.md
+++ b/docs/basic-setup-guide.md
@@ -1,0 +1,187 @@
+# H5P Standalone direct use guide
+
+Jan 2025
+
+A simple setup / "hello world" guide to get H5P Standalone player
+up and running for people not so familiar with front end web
+development.  We'll use the "direct use" style.
+
+## Basic page and a web server
+
+Let's get a web server up and serving a local page.
+
+First, create a directory for our demo to live in:
+
+```bash
+mkdir h5p-standalone-demo
+cd h5p-standalone-demo
+```
+
+Next we need to create an `index.html` file.  Use your favourite
+text editor and copy the text below:
+
+```html
+<!-- filename: index.html -->
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>H5P Standalone Demo</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+
+  <body>
+    <h2>H5P container below:</h2>
+
+    <div class="h5p-standalone-container"></div>
+  </body>
+</html>
+```
+
+You can use almost any web server but for demonstration purposes
+we'll use use one of these two.
+
+If you have [Docker](https://docs.docker.com/engine/install/) installed
+then we can use [Nginx](https://nginx.org/):
+
+```bash
+sudo docker run -it --rm -v $(pwd):/usr/share/nginx/html -p 8080:80 nginx:stable-alpine
+```
+
+If you don't have docker installed but do have Python 3 available
+we can use Python's built in server:
+
+```bash
+python3 -m http.server
+```
+
+At this point you should be able to open a browser and go to
+`http://localhost:8080/`.  You should be able to see the text
+"H5P container below:" on the page.
+
+## Add H5P Standalone
+
+In another terminal window or tab (so we can leave the web server
+running), change into your `h5p-standalone-demo` directory
+and make an `assets/h5p-standalone` directory:
+
+```bash
+mkdir -p assets/h5p-standalone
+```
+
+Now we need to get the zip file from the latest [release](https://github.com/tunapanda/h5p-standalone/releases/latest).
+
+At the time of writing, this is 3.8.0.  We can now unzip the release
+into our new `assets/h5p-standalone` directory:
+
+```bash
+unzip ~/Downloads/h5p-standalone-3.8.0.zip -d assets/h5p-standalone
+```
+
+This should create a directory structure something like this:
+```bash
+find . -type d
+
+.
+./assets
+./assets/h5p-standalone
+./assets/h5p-standalone/dist
+./assets/h5p-standalone/dist/fonts
+./assets/h5p-standalone/dist/fonts/open-sans
+./assets/h5p-standalone/dist/styles
+./assets/h5p-standalone/dist/images
+```
+
+Now we can edit the `index.html` file to load the player.
+
+1) Add the `<script>` tag in the head to load the main bundle
+2) Add the `<script>` tag under the div to initialise the player.
+
+```html
+<!-- filename: index.html -->
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>H5P Standalone Demo</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script type="text/javascript" src="assets/h5p-standalone/dist/main.bundle.js"></script>
+  </head>
+
+  <body>
+    <h2>H5P container below:</h2>
+
+    <div class="h5p-standalone-container"></div>
+
+    <script>
+      function initH5P() {
+        const el = document.querySelector(".h5p-standalone-container");
+
+        new H5PStandalone.H5P(el, {
+          h5pJsonPath: 'h5p',
+          frameJs: 'assets/h5p-standalone/dist/frame.bundle.js',
+          frameCss: 'assets/h5p-standalone/dist/styles/h5p.css',
+        });
+      }
+
+      initH5P();
+    </script>
+
+  </body>
+</html>
+```
+
+At this point we have the player all setup but we don't have any H5P
+content to play, so let's get some.
+
+## Unzip the .h5p file
+
+In this example we'll use the [Question Set](https://h5p.org/question-set)
+example from h5p.org.  In the bottom left of the example on h5p.org
+is a 'Reuse' button.  Click that and choose "Download as an .h5p file".
+
+At the time of writing, this gives us "question-set-616.h5p".
+
+1) Make a directory to put the H5P content in:
+
+```bash
+mkdir h5p
+```
+
+The name of this directory must match the `h5pJsonPath` value above.
+
+2) Unzip the h5p file into our new directory
+
+```bash
+unzip ~/Downloads/question-set-616.h5p -d h5p
+```
+
+We're now left with a directory structure something like this:
+
+```bash
+find . -type d
+
+.
+./h5p
+./h5p/content
+./h5p/content/images
+./h5p/H5P.QuestionSet-1.20
+./assets
+./assets/h5p-standalone
+./assets/h5p-standalone/dist
+./assets/h5p-standalone/dist/fonts
+./assets/h5p-standalone/dist/fonts/open-sans
+./assets/h5p-standalone/dist/styles
+./assets/h5p-standalone/dist/images
+```
+
+If you reload the page, you should see your H5P content!
+
+Hopefully by now the main [README.md](/README.md) documentation makes more sense.
+
+If you'd like some kind of loading indicator, see the
+[Loading indicator guide](loading-indicator-guide.md).

--- a/docs/loading-indicator-guide.md
+++ b/docs/loading-indicator-guide.md
@@ -1,0 +1,283 @@
+# A simple loading indicator guide
+
+Jan 2025
+
+If your users are not on a fast connection, sometimes it can take
+a few seconds to load all the H5P libraries, images and videos
+that you need to display the H5P content.
+
+In this case it can be useful to show the users that something
+is happening while they wait.
+
+## Prerequisites
+
+This guide assumes that you've read the [Basic Setup Guide](basic-setup-guide.md)
+and have a working H5P Standalone player.
+
+## Loading text
+
+First we need a little custom JavaScript to tell the main page when
+the H5P frame has loaded.  We'll add a `custom-js` directory to keep
+our custom JavaScript file in:
+
+```bash
+mkdir assets/h5p-standalone/custom-js
+```
+
+Now we can create the `assets/h5p-standalone/custom-js/finished-loading`
+file, use your favourite text editor and add this:
+
+```javascript
+// Filename: assets/h5p-standalone/custom-js/finished-loading.js
+const bc = new BroadcastChannel('h5p-loading');
+bc.postMessage('h5p-finished-loading');
+```
+
+Next we need to edit the `index.html` file.  We'll be adding
+the `<style>` stylesheet to the head element, we'll add the
+`loading` div to the main `h5p-standalone-container` and
+add the `customJs` option to the H5P Standalone player.
+We'll also subscribe to messages on a broadcast channel.
+
+Your `index.html` file should now look like this:
+
+```html
+<!-- filename: index.html -->
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>H5P Standalone Demo</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script type="text/javascript" src="assets/h5p-standalone/dist/main.bundle.js"></script>
+    <style>
+      .loading {
+        display: grid;
+        place-items: center;
+        height: 192px;
+        background-color: #dddddd;
+        border-radius: 2rem;
+      }
+
+      .loading.hidden {
+        display: none;
+        visibility: hidden;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h2>H5P container below:</h2>
+
+    <div class="h5p-standalone-container">
+      <div class="loading">
+        <h3>Loading ...</h3>
+      </div>
+    </div>
+
+    <script>
+      function initH5P() {
+        const el = document.querySelector(".h5p-standalone-container");
+        const loading = document.querySelector('.loading');
+        const bc = new BroadcastChannel('h5p-loading');
+
+        bc.onmessage = (e) => {
+          if (e.data === 'h5p-finished-loading') {
+            loading.classList.add('hidden');
+          }
+        }
+
+
+        new H5PStandalone.H5P(el, {
+          h5pJsonPath: 'h5p',
+          frameJs: 'assets/h5p-standalone/dist/frame.bundle.js',
+          frameCss: 'assets/h5p-standalone/dist/styles/h5p.css',
+          customJs: 'assets/h5p-standalone/custom-js/finished-loading.js',
+        });
+      }
+
+      initH5P();
+    </script>
+
+  </body>
+</html>
+```
+
+### How does it work?
+
+As the H5P Standalone player loads the H5P content, it creates an
+[iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)
+for the content to render inside.  The `customJs` option allows us
+to load some custom JavaScript _inside_ the iframe.
+
+We can then use a [Broadcast Channel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel)
+to let the parent page know that the iframe has rendered, which
+means we can hide the loading message.  This works because the
+iframe and the parent page are running from the same [origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin).
+
+You can think of the Broadcast Channel like a fanout in a messaging
+system.  Or like an FM radio broadcast, anyone that's listening
+on that frequency (or in our case, the 'topic' of 'h5p-loading')
+will hear the message.
+
+### How to see it working?
+
+You may find that your H5P content loads so fast that it's hard to
+see the loading message, especially if you're running the web
+server locally.
+
+Both Firefox and Chrome have a throttling feature in their developer
+tools that lets you mimic a slower connection.
+
+If you right click on the page and choose 'inspect' this will
+bring up the developer tools.
+
+In the 'Network' tab, you should find a drop down next to the 'Disable Cache'
+checkbox that by default says 'No throttling'.  If you choose a
+regular 3G preset and reload the page, you should now be able to
+see your loading indicator before the H5P content replaces it.
+
+### Tuning
+
+Without tuning, this could create some jumps while loading because
+we don't know the height of the H5P element until it's loaded
+(sometimes know as CSS jank).
+
+To mitigate this, you can match the `height` of your loading
+box to the height of your H5P element (once you know what it is):
+
+```css
+    <style>
+      .loading {
+        display: grid;
+        place-items: center;
+---->   height: 192px;
+        background-color: #dddddd;
+        border-radius: 2rem;
+      }
+
+      .loading.hidden {
+        display: none;
+        visibility: hidden;
+      }
+    </style>
+```
+
+## Fancier spinner
+
+If you'd like a fancier version, you could use some CSS animation
+to spin a spinner while the H5P content loads.
+
+```html
+<!-- filename: index.html -->
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>H5P Standalone Loading Spinner Demo</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script type="text/javascript" src="assets/h5p-standalone/dist/main.bundle.js"></script>
+    <style>
+      .loading-spinner {
+        display: grid;
+        place-items: center;
+      }
+
+      .loading-spinner.hidden {
+        display: none;
+        visibility: hidden;
+      }
+
+      .loading-spinner svg {
+        width: 96px;
+        height: 96px;
+      }
+
+      .loading-spinner .dynamic {
+        display: none;
+        visibility: hidden;
+      }
+
+      @media screen and (prefers-reduced-motion: no-preference) {
+        .loading-spinner .static {
+          display: none;
+          visibility: hidden;
+        }
+
+        .loading-spinner .dynamic {
+          display: block;
+          visibility: visible;
+          animation-duration: 3s;
+          animation-delay: 0.5s;
+          animation-timing-function: linear;
+          animation-iteration-count: infinite;
+          animation-direction: normal;
+          animation-name: spinner;
+        }
+
+      }
+
+      @keyframes spinner {
+        from {
+          transform: rotate(0turn)
+        }
+
+        to {
+          transform: rotate(1turn)
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+
+    <h2>H5P container below:</h2>
+
+    <div class="loading-spinner">
+      <svg class="static material-icons hourglass" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M320-160h320v-120q0-66-47-113t-113-47q-66 0-113 47t-47 113v120ZM160-80v-80h80v-120q0-61 28.5-114.5T348-480q-51-32-79.5-85.5T240-680v-120h-80v-80h640v80h-80v120q0 61-28.5 114.5T612-480q51 32 79.5 85.5T720-280v120h80v80H160Z"/><desc>Loading H5P ...</desc></svg>
+      <svg class="dynamic material-icons progress_activity" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M480-80q-82 0-155-31.5t-127.5-86Q143-252 111.5-325T80-480q0-83 31.5-155.5t86-127Q252-817 325-848.5T480-880q17 0 28.5 11.5T520-840q0 17-11.5 28.5T480-800q-133 0-226.5 93.5T160-480q0 133 93.5 226.5T480-160q133 0 226.5-93.5T800-480q0-17 11.5-28.5T840-520q17 0 28.5 11.5T880-480q0 82-31.5 155t-86 127.5q-54.5 54.5-127 86T480-80Z"/><desc>Loading H5P ...</desc></svg>
+    </div>
+    <div class="h5p-standalone-container"></div>
+
+
+    <script>
+      function initH5P() {
+        const el = document.querySelector(".h5p-standalone-container");
+        const loading = document.querySelector(".loading-spinner");
+        const bc = new BroadcastChannel("h5p-loading");
+
+        bc.onmessage = (e) => {
+          if (e.data === "h5p-finished-loading") {
+            loading.classList.add("hidden");
+          }
+        }
+
+        new H5PStandalone.H5P(el, {
+          h5pJsonPath: 'h5p',
+          frameJs: 'assets/h5p-standalone/dist/frame.bundle.js',
+          frameCss: 'assets/h5p-standalone/dist/styles/h5p.css',
+          customJs: 'assets/h5p-standalone/js/finished-loading.js',
+        });
+      }
+
+      initH5P();
+
+    </script>
+  </body>
+</html>
+```
+
+This uses SVG symbols from Google's [Material Symbols](https://fonts.google.com/icons?selected=Material+Symbols+Outlined:progress_activity:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=loading&icon.size=24&icon.color=%235f6368)
+but you could swap these SVGs for one of your own creations, just
+don't forget to add the `<desc>` (description) so that screen readers
+have something to read.
+
+This will spin the 'dynamic' spinner image unless the user prefers
+reduced motion, in which case it'll show the 'static' SVG.
+
+There are many ways to create loading indicators, these are just
+two examples.  Have fun and see what you can create!

--- a/docs/loading-indicator-guide.md
+++ b/docs/loading-indicator-guide.md
@@ -24,7 +24,7 @@ our custom JavaScript file in:
 mkdir assets/h5p-standalone/custom-js
 ```
 
-Now we can create the `assets/h5p-standalone/custom-js/finished-loading`
+Now we can create the `assets/h5p-standalone/custom-js/finished-loading.js`
 file, use your favourite text editor and add this:
 
 ```javascript


### PR DESCRIPTION
Hopefully this should resolve #150

Adds a basic 'direct use' guide for people not so familiar with front end web development.

However, there is a caveat.  At the moment examples downloaded from https://h5p.org/content-types-and-applications
don't seem to have the libraries inside the .h5p file!

The H5P docs don't seem to have changed either, so it looks like the libraries should still be there:
https://h5p.org/documentation/developers/h5p-specification

So as it stands, the guide won't work as is with the h5p.org examples.  I think we have three options at the moment:

1) Wait until H5P Group fix their examples
2) Wait until H5P Group update their docs (maybe they're moving towards a central download of all content types?)
3) Add a note in the guide to explain what's going on at the moment

Feel free to edit it.  Thank you so much for writing this H5P player!
